### PR TITLE
PRO-3123 Make bill status code script triggerable by cronjob and wire in rails apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ docs/_build/
 
 # Local things
 /dev/
+
+# Stuff from Prolegis import scripts
+bill_status_codes.json
+bill_status_codes_import_log.txt


### PR DESCRIPTION
## Why
In previous work, we set up a new EC2 instance to clone this repository (`Prolegis/congress`). We also introduced a script, `generate_bill_status_codes.sh`, which leverages UnitedStatesIO’s scripts to calculate bill status codes and upload them to S3.

To finalize this setup, the following tasks are needed:
- Update the script so it can be executed by a cron job.
- Use the Rails API to fetch the current Congress dynamically, rather than hardcoding it as 118.
- Enable the bill status code importer for staging, demo, and production environments.

## How
To enable the script to run via cron, I added the following line to ensure the correct directory is used:  
`cd ~/congress || exit`

This is necessary because cron jobs use a single configuration file for the entire EC2 instance. There is no separate configuration file specifically for the congress repository, so we need to guarantee the script runs from the appropriate directory, whether manually or through the cron job.

Additionally, I updated the script to fetch the current Congress programmatically from the Rails API, eliminating the need for hardcoding. Finally, I added cURL commands to trigger the bill status code importer across staging, demo, and production environments.