### PR TITLE
PRO-3160 Fix issues with `generate_bill_status_codes.sh` script

### DIFF
--- a/generate_bill_status_codes.sh
+++ b/generate_bill_status_codes.sh
@@ -1,20 +1,42 @@
 #!/bin/bash
 
+#### STEP 1 - SETUP
+#
+
+source ~/.bash_profile
+
 cd ~
 
 cd congress || git clone "https://$GITHUB_PERSONAL_ACCESS_TOKEN@github.com/Prolegis/congress.git" && cd congress
 git pull # Fetch the latest version of the congress repository from GitHub
 
+
 output_file="bill_status_codes.json" # Output JSON file
+rm -f output_file # rm the old output file
+
 log_file="bill_status_codes_import_log.txt" # Log file
-echo "Bill Status Codes Import started at $(date '+%Y-%m-%d %H:%M:%S')" >> log_file
+echo "Bill Status Codes Import started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
 # Use the Rails API to fetch the current congress
+echo "Fetch current congress at started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 CURRENT_CONGRESS=$(curl -s -H "Authorization: $API_KEY_PRODUCTION" https://www.prolegis.com/api/congress_repo/current_congress | jq -r '.current_congress')
+echo "Fetch current congress at completed at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
-# Download the data
+#### STEP 2 - DOWNLOAD BILL STATUS CODES DATA
+#
+
+echo "Download data (usc-run govinfo) started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 usc-run govinfo --cached --bulkdata=BILLSTATUS --congress=$CURRENT_CONGRESS
+echo "Download data (usc-run govinfo) completed at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
+echo "Download data (usc-run bills) started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 usc-run bills --congress=$CURRENT_CONGRESS
+echo "Download data (usc-run bills) completed at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
+#### STEP 3 - PARSE BILL STATUS CODES DATA INTO A JSON FILE
+#
+
+echo "Parse data started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
 # Initialize an empty JSON array
 echo "[" > $output_file
@@ -26,41 +48,53 @@ first_entry=true
 data_directory="data/$CURRENT_CONGRESS"
 
 # Recursively search for data.json files within the subdirectories under <ROOT>/data/$CURRENT_CONGRESS
-find "$data_directory" -type f -name "data.json" | while read -r file; do
+find "$data_directory/bills" -type f -name "data.json" | while read -r file; do
   # Extract the "bill_id" and "status" values from each data.json
   bill_id=$(jq -r '.bill_id' "$file")
   bill_status=$(jq -r '.status | ascii_upcase' "$file")  # Convert status to uppercase
 
   # Skip if bill_id is null or empty
   if [ "$bill_id" = "null" ] || [ -z "$bill_id" ]; then
-    echo "Skipping null or empty bill_id in file: $file"
+    echo "Skipping null or empty bill_id in file: $file" >> $log_file
     continue
   fi
 
-  echo "bill_data_id: $bill_id, status: $bill_status"
-
-  # Add a comma before the next entry unless it's the first one
-  if [ "$first_entry" = false ]; then
-    echo "," >> $output_file
-  fi
-
   # Append the values to the output file in JSON format
-  echo "  { \"bill_data_id\": \"$bill_id\", \"status\": \"$bill_status\" }" >> $output_file
-
-  # Set the flag to false after the first entry
-  first_entry=false
+  echo "  { \"bill_data_id\": \"$bill_id\", \"status\": \"$bill_status\" }," >> $output_file
 done
+
+# Remove the trailing space and comma from the file
+truncate -s -2 $output_file
 
 # Close the JSON array
 echo "]" >> $output_file
 
-# AWS S3 Copy with variable interpolation for CURRENT_CONGRESS
+echo "Parse data ended at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
+#### STEP 4 - UPLOAD DATA TO AWS S3 BUCKET
+#
+
+echo "AWS Upload Started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
 aws s3 cp bill_status_codes.json s3://content.prolegis.com/bill_status_codes/${CURRENT_CONGRESS}_congress_bill_status_codes.json --acl public-read
+echo "AWS Upload Completed at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
-# Trigger Async Bill Status Codes Import in Rails Application
+#### STEP 5 - TRIGGER ASYNC BILL STATUS CODES IMPORT IN RAILS APPLICATIONS
+#
+
+echo "Trigger async import in Production started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 curl -X POST https://www.prolegis.com/api/congress_repo/trigger_import_bill_status_codes -H "Authorization: $API_KEY_PRODUCTION"
-curl -X POST https://stg.prolegis.com/api/congress_repo/trigger_import_bill_status_codes -H "Authorization: $API_KEY_STAGING"
-curl -X POST https://demo.prolegis.com/api/congress_repo/trigger_import_bill_status_codes -H "Authorization: $API_KEY_DEMO"
+echo "Trigger async import in Production ended at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
-# Log that the import has completed
+echo "Trigger async import in Staging started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+curl -X POST https://stg.prolegis.com/api/congress_repo/trigger_import_bill_status_codes -H "Authorization: $API_KEY_STAGING"
+echo "Trigger async import in Staging ended at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
+echo "Trigger async import in Demo started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+curl -X POST https://demo.prolegis.com/api/congress_repo/trigger_import_bill_status_codes -H "Authorization: $API_KEY_DEMO"
+echo "Trigger async import in Demo ended at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
+
+#### STEP 6 - LOG THAT THE IMPORTER HAS BEEN COMPLETED
+#
+
 echo "Import finished at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file


### PR DESCRIPTION
## Why
There are currently two issues with the `generate_bill_status_codes.sh` shell script.

1. **Cronjob Environment Variables**: The cronjob cannot trigger the script asynchronously because it does not load the necessary environment variables by default.
  
2. **Invalid JSON Format**: The generated `bill_status_codes.json` file is not in a valid JSON format, as it includes trailing commas between entries, resulting in a structure like this:

```json
[
  { "bill_data_id": "sres57-118", "status": "PASSED:SIMPLERES" }
,
  { "bill_data_id": "sres68-118", "status": "PASSED:SIMPLERES" }
,
  { "bill_data_id": "sres50-118", "status": "REPORTED" }
,
  { "bill_data_id": "sres66-118", "status": "PASSED:SIMPLERES" }
,
  { "bill_data_id": "sres59-118", "status": "PASSED:SIMPLERES" }
,
  { "bill_data_id": "sres22-118", "status": "PASSED:SIMPLERES" }
,
  { "bill_data_id": "sres14-118", "status": "REFERRED" }
,
  { "bill_data_id": "sres13-118", "status": "PASSED:SIMPLERES" }
]
```

This is causing [this Sentry error](https://prolegis.sentry.io/share/issue/39dc152478134fc594a43b159f3572dd/) when the Rails app attempts to pull `bill_status_codes.json` from S3.

## How
1. **Environment Variable Fix**: Added `source ~/.bash_profile` at the start of the shell script to load the required environment variables for the cronjob.

2. **JSON Formatting Fix**: Updated the logic for generating `bill_status_codes.json` by initially appending commas to each entry, without managing a trailing comma manually. To ensure valid JSON format, I used the `truncate` command to remove the last comma and space, leaving a correctly formatted JSON structure.

This approach should resolve the Sentry error by ensuring the file is uploaded in the correct JSON format.