### PR TITLE
PRO-3261 Fix Bug to Ensure Correct Directory for AWS S3 Upload

### DIFF
--- a/generate_bill_status_codes.sh
+++ b/generate_bill_status_codes.sh
@@ -74,6 +74,15 @@ echo "Parse data ended at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 #### STEP 4 - UPLOAD DATA TO AWS S3 BUCKET
 #
 
+# After generating the JSON file with the required bill status data,
+# we navigate back to the root directory of the `congress` project.
+# This ensures that the working directory is correctly set to access the
+# generated file (`bill_status_codes.json`) while executing the AWS S3
+# upload command. Maintaining the correct directory is crucial for
+# seamless file handling and avoiding any potential errors during the
+# upload process.
+cd ~/congress
+
 echo "AWS Upload Started at $(date '+%Y-%m-%d %H:%M:%S')" >> $log_file
 
 aws s3 cp bill_status_codes.json s3://content.prolegis.com/bill_status_codes/${CURRENT_CONGRESS}_congress_bill_status_codes.json --acl public-read


### PR DESCRIPTION
### Context

This pull request includes an update to the script responsible for generating and uploading bill status codes data to an AWS S3 bucket. The added line ensures the working directory is correctly set to the root of the `congress` project before attempting the S3 upload.

### Problem

Previously, the script did not explicitly set the working directory back to the root of the `congress` project after navigating to subdirectories during data parsing. This could lead to issues during the AWS S3 upload step if the working directory was not correctly aligned with the expected location of the generated file (`bill_status_codes.json`).

This was working because I accidentally added in this hotfix on the EC2 instance. Once I deployed the changes to the README, it reverted the change you're seeing in this PR. Therefore, we need to add it in.

### Solution

The line `cd ~/congress` was added to ensure the script returns to the root directory of the `congress` project. This guarantees that the file is accessible and prevents potential file-not-found errors or incorrect relative paths during the upload step.

### Impact

This change improves the script's reliability by:

1. Ensuring proper file handling for the AWS S3 upload step.
2. Preventing potential runtime errors due to incorrect working directories.
3. Enhancing the maintainability of the script by making the file access logic more explicit.

### Testing

- Script was run locally environment to verify the working directory is properly set before the AWS S3 upload step.
- Verified that the file `bill_status_codes.json` is successfully uploaded to the designated S3 bucket after the change.